### PR TITLE
Specify php minimum version for this library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "sort-packages": true
     },
     "require-dev": {
-        "php": "^7.3 || ^8.0",
         "nicmart/tree": "^0.3.0",
         "phpunit/phpunit": "^9.3",
         "twig/twig": "^3.0"
     },
     "require": {
+        "php": "^7.3 || ^8.0",
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The syntax used by code requires:
- 7.0 for `declare(strict_types=1);`
- 7.1 for `const` visibility

but it's very unlikely you want to support mixed versions, one for runtime other for development,
so I assumed it was a mistake, and just moved the php engine from "require-dev" to "require".